### PR TITLE
feat : Chapter 2 - Deploy a Configurable Web Server

### DIFF
--- a/02-getting-started/03-configurable-web-server/main.tf
+++ b/02-getting-started/03-configurable-web-server/main.tf
@@ -1,0 +1,38 @@
+provider "aws" {
+  region      = "us-east-2"
+}
+
+
+variable "server_port" {
+  description = "The prot the server will use for HTTP request"
+  type        = number
+  default     = 8080
+}
+
+
+resource "aws_instance" "fusion" {
+  ami                    = "ami-0d5d9d301c853a04a"
+  instance_type          = "t2.micro"
+  vpc_security_group_ids = [aws_security_group.instance.id]
+
+  user_data = <<-EOF
+              #!/bin/bash
+              echo "Hello, World" > index.html
+              nohup busybox httpd -f -p ${var.server_port} &
+              EOF
+
+  tags = {
+    Name = "terraform-example"
+  }
+}
+
+resource "aws_security_group" "instance" {
+  name = "terraform-example-instance"
+
+  ingress {
+    from_port   = var.server_port
+    to_port     = var.server_port
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/02-getting-started/03-configurable-web-server/main.tf
+++ b/02-getting-started/03-configurable-web-server/main.tf
@@ -36,3 +36,9 @@ resource "aws_security_group" "instance" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
+
+
+output "public_ip" {
+  value       = aws_instance.fusion.public_ip
+  description = "The public IP address of the web server"
+}


### PR DESCRIPTION
## What does this PR do?
-  Makes the code more configurable by allowing to update in one place the server port which is declared in both the security group and the User Data configuration.
- Defines an input variable called `server_port` with the value `8080` as default, and makes reference to it from the `aws_security_group` and the `user_data` arguments.
- Defines an output variable with the IP address of the EC2 instance created.

## Where should the reviewer start?
- `02-getting-started/03-configurable-web-server/main.tf` 

## What is the chapter number and exercise name related to this PR?
**Chapter 2, Getting Started with Terraform -> Deploy a Configurable Web Server**